### PR TITLE
runScript: do not print second argument if NULL

### DIFF
--- a/logrotate.c
+++ b/logrotate.c
@@ -458,7 +458,7 @@ static int runScript(struct logInfo *log, char *logfn, char *logrotfn, char *scr
 
     if (debug) {
         message(MESS_DEBUG, "running script with args %s %s: \"%s\"\n",
-                logfn, logrotfn, script);
+                logfn, logrotfn ? logrotfn : "", script);
         return 0;
     }
 


### PR DESCRIPTION
fixes gcc-10 warnings:

In function ‘runScript’,
    inlined from ‘shred_file’ at logrotate.c:618:13:
logrotate.c:460:9: warning: ‘%s’ directive argument is null [-Wformat-overflow=]
  460 |         message(MESS_DEBUG, "running script with args %s %s: \"%s\"\n",
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  461 |                 logfn, logrotfn, script);
      |                 ~~~~~~~~~~~~~~~~~~~~~~~~
In function ‘runScript’,
    inlined from ‘rotateLogSet’ at logrotate.c:2255:17,
    inlined from ‘main’ at logrotate.c:2987:15:
logrotate.c:460:9: warning: ‘%s’ directive argument is null [-Wformat-overflow=]
  460 |         message(MESS_DEBUG, "running script with args %s %s: \"%s\"\n",
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  461 |                 logfn, logrotfn, script);
      |                 ~~~~~~~~~~~~~~~~~~~~~~~~
In function ‘runScript’,
    inlined from ‘rotateLogSet’ at logrotate.c:2409:17,
    inlined from ‘main’ at logrotate.c:2987:15:
logrotate.c:460:9: warning: ‘%s’ directive argument is null [-Wformat-overflow=]
  460 |         message(MESS_DEBUG, "running script with args %s %s: \"%s\"\n",
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  461 |                 logfn, logrotfn, script);
      |                 ~~~~~~~~~~~~~~~~~~~~~~~~
In function ‘runScript’,
    inlined from ‘rotateLogSet’ at logrotate.c:2320:21,
    inlined from ‘main’ at logrotate.c:2987:15:
logrotate.c:460:9: warning: ‘%s’ directive argument is null [-Wformat-overflow=]
  460 |         message(MESS_DEBUG, "running script with args %s %s: \"%s\"\n",
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  461 |                 logfn, logrotfn, script);
      |                 ~~~~~~~~~~~~~~~~~~~~~~~~